### PR TITLE
chore: importa modulo produto no modulo carrinho

### DIFF
--- a/src/cart/cart.module.ts
+++ b/src/cart/cart.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CartController } from './cart.controller';
 import { CartService } from './cart.service';
+import { ProductModule } from 'src/product/product.module';
 
 @Module({
+  imports: [ProductModule],
   controllers: [CartController],
   providers: [CartService],
 })


### PR DESCRIPTION
O modulo Carrinho vai depender do modulo do Produto, porem nesse momento ao importar o Modulo Produto eu acabo expondo     a rota /product na minha aplicação do Carrinho. 
![image](https://github.com/user-attachments/assets/3bbdb6ba-14c5-4edc-897e-36d5288f95bb)
