### PR TITLE
refactor: separa os modulos para expor a controller onde necessario

### DIFF
--- a/src/cart/cart.module.ts
+++ b/src/cart/cart.module.ts
@@ -5,7 +5,13 @@ import { ProductModule } from 'src/product/product.module';
 
 @Module({
   imports: [ProductModule],
-  controllers: [CartController],
   providers: [CartService],
+  exports: [CartService],
 })
 export class CartModule {}
+
+@Module({
+  imports: [CartModule],
+  controllers: [CartController],
+})
+export class CartHttpModule {}

--- a/src/cart/main.ts
+++ b/src/cart/main.ts
@@ -1,8 +1,8 @@
 import { NestFactory } from '@nestjs/core';
-import { CartModule } from './cart.module';
+import { CartHttpModule } from './cart.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(CartModule);
+  const app = await NestFactory.create(CartHttpModule);
   await app.listen(4000);
 }
 bootstrap();

--- a/src/product/main.ts
+++ b/src/product/main.ts
@@ -1,8 +1,8 @@
 import { NestFactory } from '@nestjs/core';
-import { ProductModule } from './product.module';
+import { ProductHttpModule } from './product.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(ProductModule);
+  const app = await NestFactory.create(ProductHttpModule);
   await app.listen(3000);
 }
 bootstrap();

--- a/src/product/product.module.ts
+++ b/src/product/product.module.ts
@@ -3,7 +3,14 @@ import { ProductController } from './product.controller';
 import { ProductService } from './product.service';
 
 @Module({
-  controllers: [ProductController],
+  controllers: [],
   providers: [ProductService],
+  exports: [ProductService],
 })
 export class ProductModule {}
+
+@Module({
+  imports: [ProductModule],
+  controllers: [ProductController],
+})
+export class ProductHttpModule {}


### PR DESCRIPTION
Separei cada modulo em 2 modulos, dessa forma o modulo carrinho nao expoe o endpoint /product 
![image](https://github.com/user-attachments/assets/bc633858-0e6b-4ac3-a6f7-1fc83180195a)
